### PR TITLE
Adds Helm chart to assist with deploying kube-secrets-init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ This can be achieved by assigning IAM Role to Kubernetes Pod with [Workload Iden
 
 Uncomment `--provider=google` flag in the [deployment.yaml](https://github.com/doitintl/kube-secrets-init/blob/master/deployment/deployment.yaml) file.
 
+If using a private GKE cluster, you will need to add a firewall rule to allow the cluster master to communicate with the webhook so that `Pods` can be scheduled. Without this rule, deploying this tool using either deployment option will result in unschedulable `Pods`.
+
+Example:
+
+| Rule Name            | Network             | Direction | Port   | Source Filter       |
+| -------------------- | ------------------- | --------- | ------ | ------------------- |
+| `allow-secrets-init` | VPC Cluster Network | `Ingress` | `8443` | Cluster Master CIDR |
+
 ## `kube-secrets-init` deployment
 
 1. To deploy the `kube-secrets-init` server, we need to create a webhook service and a deployment in our Kubernetes cluster. It’s pretty straightforward, except one thing, which is the server’s TLS configuration. If you’d care to examine the [deployment.yaml](https://github.com/doitintl/kube-secrets-init/blob/master/deployment/deployment.yaml) file, you’ll find that the certificate and corresponding private key files are read from command line arguments, and that the path to these files comes from a volume mount that points to a Kubernetes secret:
@@ -160,3 +168,7 @@ kubectl create -f deployment/clusterrole.yaml
 # define a cluster role binding
 kubectl create -f deployment/clusterrolebinding.yaml
 ```
+
+## Helm Deployment
+
+Optionally, you can use the Helm chart located within `charts/` to deploy using Helm. View the readme for details. The two scripts that must be run are included with the chart with a small modification to the script to retrieve the `caBundle`. The chart assists in installing the application into a cluster but still has the same prerequisites.

--- a/charts/secrets-init/Chart.yaml
+++ b/charts/secrets-init/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: 0.2.11
+description: A Helm Chart to deploy DoIT International's kube-secrets-init application.
+maintainers:
+  - name: Scott Hawkins
+    email: s.hawkins@calendly.com
+name: secrets-init
+sources:
+  - https://github.com/doitintl/kube-secrets-init
+type: application
+version: 0.1.0

--- a/charts/secrets-init/README.md
+++ b/charts/secrets-init/README.md
@@ -1,0 +1,37 @@
+# secrets-init Helm Chart
+
+A Helm Chart the installs DoIT International's [kube-secrets-init](https://github.com/doitintl/kube-secrets-init) application into a Kubernetes cluster.
+
+Please consult the applicatoin's documentation for specifics regarding behavior, etc.
+
+## Prerequisites
+
+Before you can deploy the Helm chart, you'll need to perform two tasks to make sure the application has what it needs within the Kubernetes cluster.
+
+1. Use `scripts/webhook-retrieve-ca-bundle.sh` to obtain the Kubernetes server CA bundle. This will be set in the variable `webhook.caBundle` in this chart and supplied to the application. Set this in the values file however you see fit before installing the Chart.
+2. Use `scripts/webhook-create-signed-certificate.sh` to configure a `Secret` within the cluster containing the necessary certificate data for the application itself.
+
+Don't attempt to install the chart before accomplishing both of these tasks.
+
+When running the `webhook-create-signed-certificate.sh` script, be sure to set `namespace` on line 46:
+
+```bash
+[ -z ${namespace} ] && namespace=default # OVERRIDE THIS IF CHANGING
+```
+
+## Parameters
+
+| Parameter            | Description                                                                | Default                      | Required |
+| -------------------- | -------------------------------------------------------------------------- | ---------------------------- | -------- |
+| `deployment.enabled` | Enable or disable the `Deployment`.                                        | `true`                       | No       |
+| `image.repository`   | Location of the image to pull.                                             | `doitintl/kube-secrets-init` | No       |
+| `image.pullPolicy`   | Image pull policy.                                                         | `IfNotPresent`               | No       |
+| `image.tag`          | Image tag.                                                                 | `0.2.11`                     | No       |
+| `logLevel`           | Log level flag passed to the application.                                  | `debug`                      | No       |
+| `provider`           | Can be either `aws` or `google`. Must provide one or the other.            | `nil`                        | Yes      |
+| `rbac.create`        | Whether or not to create `ServiceAccount` and `ClusterRole/Binding`.       | `true`                       | No       |
+| `replicaCount`       | Replica count for the `Deployment`.                                        | `1`                          | No       |
+| `service.port`       | Port to configure for the `Service`                                        | `443`                        | No       |
+| `service.targetPort` | Target port on `Pods`.                                                     | `8443`                       | No       |
+| `webhook.caBundle`   | Kubernetes API CA bundle to provide to the `MutatingWebhookConfiguration`. | `nil`                        | Yes      |
+| `webhook.domain`     | The domain to pass to the `MutatingWebhookConfiguration` configuration.    | `secrets-init.doit-intl.com` | No       |

--- a/charts/secrets-init/scripts/webhook-create-signed-cert.sh
+++ b/charts/secrets-init/scripts/webhook-create-signed-cert.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat << EOF
+Generate certificate suitable for use with an secrets-init webhook service.
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with sidecar-injector webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+The server key/cert k8s CA cert are stored in a k8s secret.
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+    --service)
+        service="$2"
+        shift
+        ;;
+    --secret)
+        secret="$2"
+        shift
+        ;;
+    --namespace)
+        namespace="$2"
+        shift
+        ;;
+    *)
+        usage
+        ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=secrets-init
+[ -z ${secret} ] && secret=secrets-init-webhook-certs
+[ -z ${namespace} ] && namespace=default # OVERRIDE THIS IF CHANGING
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat << EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2> /dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat << EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+    --from-file=key.pem=${tmpdir}/server-key.pem \
+    --from-file=cert.pem=${tmpdir}/server-cert.pem \
+    --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/charts/secrets-init/scripts/webhook-retrieve-ca-bundle.sh
+++ b/charts/secrets-init/scripts/webhook-retrieve-ca-bundle.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ROOT=$(
+  cd $(dirname $0)/../../
+  pwd
+)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CLUSTER_NAME=$(kubectl config get-contexts $(kubectl config current-context) --no-headers | awk '{print $3}')
+
+echo "Bundle data: $(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'${CLUSTER_NAME}'") | .cluster."certificate-authority-data"')"

--- a/charts/secrets-init/templates/_helpers.tpl
+++ b/charts/secrets-init/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secrets-init.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "secrets-init.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secrets-init.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secrets-init.labels" -}}
+app: {{ .Release.Name }}
+helm.sh/chart: {{ include "secrets-init.chart" . }}
+{{ include "secrets-init.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secrets-init.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "secrets-init.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/secrets-init/templates/clusterrole.yaml
+++ b/charts/secrets-init/templates/clusterrole.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - events
+    verbs:
+      - "*"
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - "*"
+  - apiGroups:
+      - autoscaling
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - secrets
+      - configmaps
+    verbs:
+      - get
+{{- end }}

--- a/charts/secrets-init/templates/clusterrolebinding.yaml
+++ b/charts/secrets-init/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "secrets-init.fullname" . }}
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "secrets-init.fullname" . }}
+{{- end }}

--- a/charts/secrets-init/templates/clusterrolebinding.yaml
+++ b/charts/secrets-init/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "secrets-init.fullname" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/secrets-init/templates/deployment.yaml
+++ b/charts/secrets-init/templates/deployment.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.deployment.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "secrets-init.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "secrets-init.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "secrets-init.fullname" . }}
+      containers:
+        - name: webhook
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- with .Values.logLevel }}
+            - --log-level={{ . }}
+            {{- end }}
+            - server
+            - --tls-cert-file=/etc/webhook/certs/cert.pem
+            - --tls-private-key-file=/etc/webhook/certs/key.pem
+            - --pull-policy=Always
+            {{- with (required "Please verify that .Values.provider is not empty!" .Values.provider) }}
+            - --provider={{ . }}
+            {{- end }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: secrets-init-webhook-certs
+{{- end }}

--- a/charts/secrets-init/templates/mutatingwebhook.yaml
+++ b/charts/secrets-init/templates/mutatingwebhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}
+webhooks:
+  - name: {{ .Values.webhook.domain }}
+    admissionReviewVersions: ["v1beta1"]
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "secrets-init.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+        path: "/pods"
+      caBundle: {{ required "Cannot provide empty value for caBundle!" .Values.webhook.caBundle }}
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods"]

--- a/charts/secrets-init/templates/service.yaml
+++ b/charts/secrets-init/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: webhook
+  selector:
+    {{- include "secrets-init.selectorLabels" . | nindent 4 }}

--- a/charts/secrets-init/templates/serviceaccount.yaml
+++ b/charts/secrets-init/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "secrets-init.fullname" . }}
+  labels:
+    {{- include "secrets-init.labels" . | nindent 4 }}

--- a/charts/secrets-init/values.yaml
+++ b/charts/secrets-init/values.yaml
@@ -1,0 +1,29 @@
+# Default values for secrets-init.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+deployment:
+  enabled: true
+
+image:
+  repository: doitintl/kube-secrets-init
+  pullPolicy: IfNotPresent
+  tag: 0.2.11
+
+logLevel: debug
+
+# Can be google or aws.
+provider: google
+
+rbac:
+  create: true
+
+replicaCount: 1
+
+service:
+  port: 443
+  targetPort: 8443
+
+webhook:
+  caBundle: ""
+  domain: secrets-init.doit-intl.com


### PR DESCRIPTION
Adds a simple Helm chart for deploying `kube-secrets-init` into a cluster. The process for creating dependencies has been adjusted a bit, but overall remains very similar. I have tested this out in my own clusters first.