### PR TITLE
Handle image:tag@sha format

### DIFF
--- a/cmd/secrets-init-webhook/registry/registry.go
+++ b/cmd/secrets-init-webhook/registry/registry.go
@@ -137,6 +137,8 @@ func getImageBlob(container *ContainerInfo, registrySkipVerify bool) (*imagev1.I
 
 // parseContainerImage returns image and reference
 func parseContainerImage(image string) (string, string) {
+	var imageName = image
+	var reference = "latest"
 	var split []string
 
 	if strings.Contains(image, "@") {
@@ -145,11 +147,16 @@ func parseContainerImage(image string) (string, string) {
 		split = strings.SplitN(image, ":", 2)
 	}
 
-	imageName := split[0]
-	reference := "latest"
-
 	if len(split) > 1 {
+		imageName = split[0]
 		reference = split[1]
+
+		// image:tag@sha256:abc is a valid image format.
+		// in that case, remove the tag from the imageName
+		if strings.Contains(imageName, ":") {
+			split = strings.SplitN(imageName, ":", 2)
+			imageName = split[0]
+		}
 	}
 
 	return imageName, reference

--- a/cmd/secrets-init-webhook/registry/registry_test.go
+++ b/cmd/secrets-init-webhook/registry/registry_test.go
@@ -1,0 +1,26 @@
+package registry
+
+import "testing"
+
+//nolint:goconst
+func TestParseContainerImage(t *testing.T) {
+	var imageName, reference = parseContainerImage("image:tag")
+	if imageName != "image" && reference != "tag" {
+		t.Errorf("parseContainerImage was incorrect, got: %s, %s want: %s, %s.", imageName, reference, "image", "tag")
+	}
+
+	imageName, reference = parseContainerImage("image")
+	if imageName != "image" && reference != "latest" {
+		t.Errorf("parseContainerImage was incorrect, got: %s, %s want: %s, %s.", imageName, reference, "image", "latest")
+	}
+
+	imageName, reference = parseContainerImage("image@abc")
+	if imageName != "image" && reference != "abc" {
+		t.Errorf("parseContainerImage was incorrect, got: %s, %s want: %s, %s.", imageName, reference, "image", "abc")
+	}
+
+	imageName, reference = parseContainerImage("image:tag@abc")
+	if imageName != "image" && reference != "abc" {
+		t.Errorf("parseContainerImage was incorrect, got: %s, %s want: %s, %s.", imageName, reference, "image", "abc")
+	}
+}


### PR DESCRIPTION
kube-secret-init doesn't handle images with the following format; `image:tag@sha256:abc`, which is adopted by tools like skaffold. Fetching the manifest would fail (for instance with a 404 with Google Container Registry). This is because it tries to fetch the manifest with `tag@sha256:abc` which is invalid. 

This PR addresses the issue. I'm not fluent in Go so feel free to point me in the right direction @alexei-led.

